### PR TITLE
fix: add custom transformer to fix icons

### DIFF
--- a/tools/importer/import.custom.js
+++ b/tools/importer/import.custom.js
@@ -34,6 +34,22 @@ export const customParsers = {};
 export const customElements = [];
 
 /**
- * Custom transformers
+ * Custom transformer to convert SVGs to PNG images after all other transforms.
+ * Replaces each SVG with an <img> using a data URL.
  */
-export const customTransformers = {};
+function svgToPngTransformer(hookName, element, payload) {
+  if (hookName !== 'afterTransform') return;
+  const svgs = element.querySelectorAll('svg');
+  svgs.forEach((svg) => {
+    const serializer = new XMLSerializer();
+    const svgString = serializer.serializeToString(svg);
+    const svgDataUrl = `data:image/svg+xml;base64,${btoa(unescape(encodeURIComponent(svgString)))}`;
+    const img = svg.ownerDocument.createElement('img');
+    img.src = svgDataUrl;
+    svg.replaceWith(img);
+  });
+}
+
+export const customTransformers = {
+  svgToPng: svgToPngTransformer,
+};


### PR DESCRIPTION
This adds a custom transformer that replaces each SVG with an <img> using a data URL. That way, the importer should convert the svgs (of icons) into png.
